### PR TITLE
Feature/base year pages

### DIFF
--- a/gui/.editorconfig
+++ b/gui/.editorconfig
@@ -4,6 +4,5 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
-end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -13,7 +13,10 @@
         "@electron-toolkit/utils": "^4.0.0",
         "@tailwindcss/vite": "^4.1.18",
         "electron-updater": "^6.3.9",
-        "react-router-dom": "^7.10.1"
+        "react-router-dom": "^7.10.1",
+        "react-slick": "^0.31.0",
+        "react-toastify": "^11.0.5",
+        "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -3972,6 +3975,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -4061,6 +4070,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -7065,6 +7083,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7123,6 +7148,15 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7479,6 +7513,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
@@ -8767,6 +8807,35 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.31.0.tgz",
+      "integrity": "sha512-zo6VLT8wuSBJffg/TFPbzrw2dEnfZ/cUKmYsKByh3AgatRv29m2LoFbq5vRMa3R3A4wp4d8gwbJKO2fWZFaI3g==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -8866,6 +8935,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -9353,6 +9428,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -9490,6 +9574,12 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/gui/package.json
+++ b/gui/package.json
@@ -25,7 +25,10 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@tailwindcss/vite": "^4.1.18",
     "electron-updater": "^6.3.9",
-    "react-router-dom": "^7.10.1"
+    "react-router-dom": "^7.10.1",
+    "react-slick": "^0.31.0",
+    "react-toastify": "^11.0.5",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/gui/python-backend/get-schedule.py
+++ b/gui/python-backend/get-schedule.py
@@ -1,0 +1,23 @@
+import fastf1
+import argparse
+from settings import enable_cache, schedule_cache
+
+enable_cache()
+
+# Force use of --year flag to get schedule for the year
+parser = argparse.ArgumentParser()
+parser.add_argument("--year", type=int, required=True)
+args = parser.parse_args()
+
+schedule_df = fastf1.get_event_schedule(args.year, include_testing=False)
+
+# Filter out unnecessary columns
+filtered_schedule_df = schedule_df[
+    ['RoundNumber', 'Country', 'Location', 'OfficialEventName']
+]
+
+# Create JSON
+schedule_json = filtered_schedule_df.to_dict(orient='records')
+schedule_cache(args.year, schedule_json)
+
+print(f"Schedule for {args.year} cached successfully.")

--- a/gui/python-backend/settings.py
+++ b/gui/python-backend/settings.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import fastf1
+import json
+
+# Determine cache directory path, same as the root of the project
+def _get_cache_dir() -> Path:
+    base_dir = Path(__file__).parent.parent.parent
+    return base_dir / ".fastf1-cache"
+
+# Enable caching for fastf1
+def enable_cache():
+    cache_dir = _get_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    fastf1.Cache.enable_cache(cache_dir)
+
+# Cache the schedule JSON for a given year
+def schedule_cache(year, schedule_json):
+    cache_dir = _get_cache_dir() / str(year)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    with open(cache_dir / "schedule.json", "w", encoding="utf-8") as f:
+        json.dump(schedule_json, f, indent=2, default=str)

--- a/gui/src/main/config.ts
+++ b/gui/src/main/config.ts
@@ -1,0 +1,24 @@
+import path from 'path'
+import fs from 'fs'
+import os from 'os'
+
+export function GetVenvPython(): string {
+  const projectRoot = path.join(__dirname, '../../../')
+  const venvFolders = ['.venv', 'venv']
+
+  for (const folder of venvFolders) {
+    const fullPath = path.join(projectRoot, folder)
+    if (fs.existsSync(fullPath)) {
+      if (os.platform() === 'win32') {
+        // Windows
+        return path.join(fullPath, 'Scripts', 'python.exe')
+      } else {
+        // Linux / macOS
+        return path.join(fullPath, 'bin', 'python')
+      }
+    }
+  }
+
+  // Fallback to system Python if no venv found
+  return 'python'
+}

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -12,6 +12,13 @@ function createWindow(): void {
   const mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
+    minWidth: 1200,
+    minHeight: 800,
+    maxWidth: 1200,
+    maxHeight: 800,
+    resizable: false,
+    fullscreenable: false,
+    maximizable: false,
     show: false,
     autoHideMenuBar: true,
     ...(process.platform === 'linux' ? { icon } : {}),

--- a/gui/src/main/index.ts
+++ b/gui/src/main/index.ts
@@ -2,10 +2,9 @@ import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
-import { spawn } from 'child_process'
-import path from 'path'
-import fs from 'fs'
-import os from 'os'
+import { GetVenvPython } from './config'
+import { registerGetScheduleIPC } from './ipc/get-schedule'
+import { registerRaceReplayIPC } from './ipc/race-replay'
 
 function createWindow(): void {
   // Create the browser window.
@@ -73,51 +72,11 @@ app.whenReady().then(() => {
   })
 })
 
-// Resolve the virtual environment folder (.venv or venv)
-function getVenvPython(): string {
-  const projectRoot = path.join(__dirname, '../../../')
-  const venvFolders = ['.venv', 'venv']
+const venvPython = GetVenvPython()
 
-  for (const folder of venvFolders) {
-    const fullPath = path.join(projectRoot, folder)
-    if (fs.existsSync(fullPath)) {
-      if (os.platform() === 'win32') {
-        // Windows
-        return path.join(fullPath, 'Scripts', 'python.exe')
-      } else {
-        // Linux / macOS
-        return path.join(fullPath, 'bin', 'python')
-      }
-    }
-  }
-
-  // Fallback to system Python if no venv found
-  return 'python'
-}
-
-// Path to the Python script
-const pythonScript = path.join(__dirname, '../../../main.py')
-
-ipcMain.on('run-python', (event, args: { year: number; round: number }) => {
-  const venvPython = getVenvPython()
-
-  const pythonArgs = [pythonScript, '--year', String(args.year), '--round', String(args.round)]
-
-  const python = spawn(venvPython, pythonArgs, {
-    cwd: path.dirname(pythonScript)
-  })
-
-  python.stdout.on('data', (data) => {
-    event.sender.send('python-output', data.toString())
-  })
-
-  python.stderr.on('data', (data) => {
-    event.sender.send('python-output', `ERROR: ${data.toString()}`)
-  })
-
-  python.on('close', (code) => {
-    event.sender.send('python-output', `Python script exited with code ${code}`)
-  })
+app.whenReady().then(() => {
+  registerGetScheduleIPC(venvPython)
+  registerRaceReplayIPC(venvPython)
 })
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/gui/src/main/ipc/get-schedule.ts
+++ b/gui/src/main/ipc/get-schedule.ts
@@ -1,0 +1,51 @@
+import { ipcMain } from 'electron'
+import { spawn } from 'child_process'
+import path from 'path'
+import fs from 'fs/promises'
+
+const pythonScript = path.join(__dirname, '../../python-backend/get-schedule.py')
+
+export function registerGetScheduleIPC(venvPython: string): void {
+  ipcMain.on('runGetSchedule', async (event, args: { year: number }) => {
+    const filePath = path.join(__dirname, `../../../.fastf1-cache/${args.year}/schedule.json`)
+
+    try {
+      // Try reading the file asynchronously
+      const scheduleJson = await fs.readFile(filePath, 'utf8')
+      const schedule = JSON.parse(scheduleJson)
+      // event.sender.send('python-output', 'Schedule loaded from cache.')
+      event.sender.send('read-data', schedule)
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException
+      if (e && e.code === 'ENOENT') {
+        const pythonArgs = [pythonScript, '--year', String(args.year)]
+        const python = spawn(venvPython, pythonArgs, { cwd: path.dirname(pythonScript) })
+
+        python.stdout.on('data', (data) => {
+          event.sender.send('python-output', data.toString())
+        })
+
+        python.stderr.on('data', (data) => {
+          event.sender.send('python-output', `ERROR: ${data.toString()}`)
+        })
+
+        python.on('close', async (code) => {
+          event.sender.send('python-output', `Python script exited with code ${code}`)
+
+          // Try reading the file again **after Python script finishes**
+          try {
+            const scheduleJson = await fs.readFile(filePath, 'utf8')
+            const schedule = JSON.parse(scheduleJson)
+            // event.sender.send('python-output', 'Schedule loaded after Python script.')
+            event.sender.send('read-data', schedule)
+          } catch (readErr) {
+            event.sender.send('python-output', `Failed to read schedule: ${readErr}`)
+          }
+        })
+      } else {
+        console.error('Error reading the file:', err)
+        event.sender.send('python-output', `Error reading schedule: ${err}`)
+      }
+    }
+  })
+}

--- a/gui/src/main/ipc/race-replay.ts
+++ b/gui/src/main/ipc/race-replay.ts
@@ -1,0 +1,27 @@
+import { ipcMain } from 'electron'
+import { spawn } from 'child_process'
+import path from 'path'
+
+export function registerRaceReplayIPC(venvPython: string): void {
+  const pythonScript = path.join(__dirname, '../../../main.py')
+
+  ipcMain.on('run-race-replay', (event, args: { year: number; round: number }) => {
+    const pythonArgs = [pythonScript, '--year', String(args.year), '--round', String(args.round)]
+
+    const python = spawn(venvPython, pythonArgs, {
+      cwd: path.dirname(pythonScript)
+    })
+
+    python.stdout.on('data', (data) => {
+      event.sender.send('python-output', data.toString())
+    })
+
+    python.stderr.on('data', (data) => {
+      event.sender.send('python-output', `ERROR: ${data.toString()}`)
+    })
+
+    python.on('close', (code) => {
+      event.sender.send('python-output', `Python script exited with code ${code}`)
+    })
+  })
+}

--- a/gui/src/preload/index.d.ts
+++ b/gui/src/preload/index.d.ts
@@ -4,8 +4,9 @@ declare global {
   interface Window {
     electron: ElectronAPI
     api: {
-      runPython: (args: { year: number; round: number }) => void
+      runGetSchedule: (args: { year: number }) => void
       onPythonOutput: (callback: (data: string) => void) => void
+      readData: (callback: (data: JSON) => void) => void
     }
   }
 }

--- a/gui/src/preload/index.ts
+++ b/gui/src/preload/index.ts
@@ -6,7 +6,11 @@ contextBridge.exposeInMainWorld('electron', electronAPI)
 
 // Expose your custom API
 contextBridge.exposeInMainWorld('api', {
-  runPython: (args: { year: number; round: number }) => ipcRenderer.send('run-python', args),
+  runGetSchedule: (args: { year: number }) => ipcRenderer.send('runGetSchedule', args),
+  runRaceReplay: (args: { year: number; round: number }) =>
+    ipcRenderer.send('run-race-replay', args),
   onPythonOutput: (callback: (data: string) => void) =>
-    ipcRenderer.on('python-output', (_, data) => callback(data))
+    ipcRenderer.on('python-output', (_, data) => callback(data)),
+  readData: (callback: (data: JSON) => void) =>
+    ipcRenderer.on('read-data', (_, data) => callback(data))
 })

--- a/gui/src/renderer/src/assets/css/globals.css
+++ b/gui/src/renderer/src/assets/css/globals.css
@@ -77,3 +77,40 @@ footer {
   justify-content: center;
   margin-bottom: 5px;
 }
+
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  background-color: black;
+  padding: 1rem;
+  margin-top: 1.25rem;
+  transition: background-color 0.3s;
+}
+
+.card:hover {
+  background-color: #1f2937;
+  cursor: pointer;
+}
+
+.card.year {
+  width: 96px;
+  height: 96px;
+}
+
+.card.race {
+  width: 350px;
+  height: 150px;
+}
+
+.event {
+  text-align: left;
+}
+
+.event.official-name,
+.event.round-number {
+  color: gray;
+  font-size: 0.8rem;
+}

--- a/gui/src/renderer/src/components/race-card.tsx
+++ b/gui/src/renderer/src/components/race-card.tsx
@@ -1,0 +1,21 @@
+interface RaceCardProps {
+  RoundNumber: number
+  Country: string
+  Location: string
+  OfficialEventName: string
+}
+
+export default function RaceCard({
+  RoundNumber,
+  Country,
+  // Location,
+  OfficialEventName
+}: RaceCardProps): React.ReactElement {
+  return (
+    <>
+      <span className="event font-bold text-2xl">{Country}</span>
+      <span className="event official-name">{OfficialEventName}</span>
+      <span className="event round-number">Round {RoundNumber}</span>
+    </>
+  )
+}

--- a/gui/src/renderer/src/components/year-card.tsx
+++ b/gui/src/renderer/src/components/year-card.tsx
@@ -4,25 +4,8 @@ interface YearCardProps {
   year: number
 }
 
-declare global {
-  interface Window {
-    api: {
-      runPython: (args: { year: number; round: number }) => void
-      onPythonOutput: (callback: (data: string) => void) => void
-    }
-  }
-}
-
 export default function YearCard({ year }: YearCardProps): React.ReactElement {
   const navigate = useNavigate()
-  // const runPython = (year: number): void => {
-  //   window.api.runPython({ year: year, round: 2 })
-
-  //   // Optional: listen to Python output
-  //   window.api.onPythonOutput((data) => {
-  //     console.log(`Python Output: ${data}`)
-  //   })
-  // }
 
   const handleClick = (): void => {
     // Navigate to the dynamic route
@@ -30,10 +13,7 @@ export default function YearCard({ year }: YearCardProps): React.ReactElement {
   }
 
   return (
-    <button
-      className="flex flex-col items-center justify-center border-white rounded-lg bg-black p-4 mt-5 w-24 h-24"
-      onClick={() => handleClick()}
-    >
+    <button className="card year" onClick={() => handleClick()}>
       <p className="text-center text-2xl font-bold">{year}</p>
     </button>
   )

--- a/gui/src/renderer/src/pages/years/[year].tsx
+++ b/gui/src/renderer/src/pages/years/[year].tsx
@@ -1,16 +1,123 @@
+import 'slick-carousel/slick/slick.css'
+import 'slick-carousel/slick/slick-theme.css'
 import { useParams, useNavigate } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import RaceCard from '../../components/race-card'
+import Slider from 'react-slick'
+import { ToastContainer, toast } from 'react-toastify'
+
+interface Race {
+  RoundNumber: number
+  Country: string
+  Location: string
+  OfficialEventName: string
+}
+
+declare global {
+  interface Window {
+    api: {
+      runGetSchedule: (args: { year: number }) => void
+      onPythonOutput: (callback: (data: string) => void) => void
+      readData: (callback: (data: Race[]) => void) => void
+      runRaceReplay: (args: { year: number; round: number }) => void
+    }
+  }
+}
 
 export default function Year(): React.ReactElement {
   const navigate = useNavigate()
   const { year } = useParams()
+  const [scheduleData, setScheduleData] = useState<Race[] | null>(null)
 
-  const handleClick = (): void => {
+  const goBack = (): void => {
     navigate('/')
   }
+
+  function startRaceReplay(round: number): void {
+    toast.info(
+      'Loading replay for round ' +
+        round +
+        '. Press F12 to open devtools console to see progress. It may take a few mins to load.',
+      {
+        position: 'bottom-right',
+        autoClose: 5000,
+        hideProgressBar: false,
+        closeOnClick: false,
+        pauseOnHover: false,
+        draggable: false,
+        progress: undefined,
+        theme: 'dark'
+      }
+    )
+    window.api.runRaceReplay({ year: Number(year), round: round })
+    window.api.onPythonOutput((data) => {
+      console.log(`Python Output: ${data}`)
+    })
+  }
+
+  useEffect(() => {
+    if (!year) return
+
+    window.api.runGetSchedule({ year: Number(year) })
+
+    window.api.onPythonOutput((data) => {
+      console.log(`Python Output: ${data}`)
+    })
+
+    window.api.readData((data) => {
+      setScheduleData(data)
+    })
+  }, [year])
+
+  const settings = {
+    centerMode: true,
+    infinite: true,
+    centerPadding: '60px',
+    slidesToShow: 3,
+    speed: 500,
+    rows: 3,
+    slidesPerRow: 1,
+    draggable: false,
+    initialSlide: 1
+  }
+
   return (
     <>
       <h1>Year: {year}</h1>
-      <button onClick={() => handleClick()}>Back</button>
+      <button onClick={goBack}>Back</button>
+      <div className="w-[95%] m-0">
+        {scheduleData && (
+          <Slider {...settings}>
+            {scheduleData.map((race, index) => (
+              <div key={index}>
+                <button
+                  className="card w-[300px] h-[150px]"
+                  onClick={() => startRaceReplay(race.RoundNumber)}
+                >
+                  <RaceCard
+                    RoundNumber={race.RoundNumber}
+                    Country={race.Country}
+                    Location={race.Location}
+                    OfficialEventName={race.OfficialEventName}
+                  />
+                </button>
+              </div>
+            ))}
+          </Slider>
+        )}
+      </div>
+      <ToastContainer
+        position="bottom-right"
+        autoClose={5000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick={false}
+        rtl={false}
+        pauseOnFocusLoss={false}
+        draggable={false}
+        pauseOnHover={false}
+        theme="dark"
+      />
     </>
   )
 }


### PR DESCRIPTION
- Introduced `get-schedule.py` and `settings.py` for caching race schedules.
- Implemented IPC handlers for fetching schedules and running race replays.
- Updated preload API to include new methods for schedule retrieval and race replay.
- Added new components for displaying race information and integrated with the UI.
- Enhanced styling for race cards and carousel display.